### PR TITLE
Fix multi-line ruby highlighting

### DIFF
--- a/syntaxes/haml.json
+++ b/syntaxes/haml.json
@@ -488,7 +488,7 @@
     "rubyline": {
       "begin": "(&amp|!)?(=|-|~)",
       "contentName": "source.ruby.embedded.haml",
-      "end": "((do|\\{)( \\|[.*]+\\|)?)$|$|^(?!.*\\|\\s*)$\\n?",
+      "end": "((do|\\{)( \\|[.*]+\\|)?)$|[^,]$|^(?!.*\\|\\s*)$\\n?",
       "endCaptures": {
         "1": {
           "name": "source.ruby.embedded.html"


### PR DESCRIPTION
Ruby highlighting is missing when having multi-line ruby code like this (after the first line):
<img width="500" alt="image" src="https://github.com/user-attachments/assets/941680bc-e61b-4684-b14b-3d1ac3ee868c" />

After this fix the highlighting works like this:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/8de28719-a7b9-4a3f-a4a1-b05d4c28fa24" />

[From HAML's documentation `,` is not supposed to end the ruby line](https://haml.info/docs/yardoc/file.REFERENCE.html#ruby-evaluation)
> A line of Ruby code can be stretched over multiple lines as long as each line but the last ends with a comma. For example:
```
= link_to_remote "Add to cart",
    :url => { :action => "add", :id => product.id },
    :update => { :success => "cart", :failure => "error" }
```
 